### PR TITLE
fix for main menu margin

### DIFF
--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -567,6 +567,7 @@ th {
 #main-menu {
   position: relative;
   left: 0;
+  margin-right: 0;
   *zoom: 1;
 }
 #main-menu:after {


### PR DESCRIPTION
all project pages with the main menu had a wide margin to the right of the page. Nothing was rendered there, so an unnecessary horizontal scroll bar was present at the bottom of the pages.

this negates the `margin-right:-500px;` declaration from [here](http://www.redmine.org/projects/redmine/repository/annotate/trunk/public/stylesheets/application.css#L33)
