### PR TITLE
Use priority name instead of priority id.

### DIFF
--- a/sass/partials/_tables.scss
+++ b/sass/partials/_tables.scss
@@ -1,28 +1,28 @@
 
-tr.odd.priority-5, table.list tbody tr.odd.priority-5:hover { color: #900; font-weight: bold; }
-tr.odd.priority-5 { background: #ffc4c4; }
-tr.even.priority-5, table.list tbody tr.even.priority-5:hover { color: #900; font-weight: bold; }
-tr.even.priority-5 { background: #ffd4d4; }
-tr.priority-5 a, tr.priority-5:hover a { color: #900; }
-tr.odd.priority-5 td, tr.even.priority-5 td { border-color: #ffb4b4; }
+tr.odd.priority-highest, table.list tbody tr.odd.priority-highest:hover { color: #900; font-weight: bold; }
+tr.odd.priority-highest { background: #ffc4c4; }
+tr.even.priority-highest, table.list tbody tr.even.priority-highest:hover { color: #900; font-weight: bold; }
+tr.even.priority-highest { background: #ffd4d4; }
+tr.priority-highest a, tr.priority-highest:hover a { color: #900; }
+tr.odd.priority-highest td, tr.even.priority-highest td { border-color: #ffb4b4; }
 
-tr.odd.priority-4, table.list tbody tr.odd.priority-4:hover { color: #900; }
-tr.odd.priority-4 { background: #ffc4c4; }
-tr.even.priority-4, table.list tbody tr.even.priority-4:hover { color: #900; }
-tr.even.priority-4 { background: #ffd4d4; }
-tr.priority-4 a { color: #900; }
-tr.odd.priority-4 td, tr.even.priority-4 td { border-color: #ffb4b4; }
+tr.odd.priority-high2, table.list tbody tr.odd.priority-high2:hover { color: #900; }
+tr.odd.priority-high2 { background: #ffc4c4; }
+tr.even.priority-high2, table.list tbody tr.even.priority-high2:hover { color: #900; }
+tr.even.priority-high2 { background: #ffd4d4; }
+tr.priority-high2 a { color: #900; }
+tr.odd.priority-high2 td, tr.even.priority-high2 td { border-color: #ffb4b4; }
 
-tr.odd.priority-3, table.list tbody tr.odd.priority-3:hover { color: #900; }
-tr.odd.priority-3 { background: #fee; }
-tr.even.priority-3, table.list tbody tr.even.priority-3:hover { color: #900; }
-tr.even.priority-3 { background: #fff2f2; }
-tr.priority-3 a { color: #900; }
-tr.odd.priority-3 td, tr.even.priority-3 td { border-color: #fcc; }
+tr.odd.priority-default, table.list tbody tr.odd.priority-default:hover { color: #900; }
+tr.odd.priority-default { background: #fee; }
+tr.even.priority-default, table.list tbody tr.even.priority-default:hover { color: #900; }
+tr.even.priority-default { background: #fff2f2; }
+tr.priority-default a { color: #900; }
+tr.odd.priority-default td, tr.even.priority-default td { border-color: #fcc; }
 
-tr.odd.priority-1, table.list tbody tr.odd.priority-1:hover { color: #559; }
-tr.odd.priority-1 { background: #eaf7ff; }
-tr.even.priority-1, table.list tbody tr.even.priority-1:hover { color: #559; }
-tr.even.priority-1 { background: #f2faff; }
-tr.priority-1 a { color: #559; }
-tr.odd.priority-1 td, tr.even.priority-1 td { border-color: #add7f3; }
+tr.odd.priority-lowest, table.list tbody tr.odd.priority-lowest:hover { color: #559; }
+tr.odd.priority-lowest { background: #eaf7ff; }
+tr.even.priority-lowest, table.list tbody tr.even.priority-lowest:hover { color: #559; }
+tr.even.priority-lowest { background: #f2faff; }
+tr.priority-lowest a { color: #559; }
+tr.odd.priority-lowest td, tr.even.priority-lowest td { border-color: #add7f3; }

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -382,101 +382,101 @@ optgroup::-moz-focus-inner {
   background: #eeeeee;
 }
 
-tr.odd.priority-5, table.list tbody tr.odd.priority-5:hover {
+tr.odd.priority-highest, table.list tbody tr.odd.priority-highest:hover {
   color: #900;
   font-weight: bold;
 }
 
-tr.odd.priority-5 {
+tr.odd.priority-highest {
   background: #ffc4c4;
 }
 
-tr.even.priority-5, table.list tbody tr.even.priority-5:hover {
+tr.even.priority-highest, table.list tbody tr.even.priority-highest:hover {
   color: #900;
   font-weight: bold;
 }
 
-tr.even.priority-5 {
+tr.even.priority-highest {
   background: #ffd4d4;
 }
 
-tr.priority-5 a, tr.priority-5:hover a {
+tr.priority-highest a, tr.priority-highest:hover a {
   color: #900;
 }
 
-tr.odd.priority-5 td, tr.even.priority-5 td {
+tr.odd.priority-highest td, tr.even.priority-highest td {
   border-color: #ffb4b4;
 }
 
-tr.odd.priority-4, table.list tbody tr.odd.priority-4:hover {
+tr.odd.priority-high2, table.list tbody tr.odd.priority-high2:hover {
   color: #900;
 }
 
-tr.odd.priority-4 {
+tr.odd.priority-high2 {
   background: #ffc4c4;
 }
 
-tr.even.priority-4, table.list tbody tr.even.priority-4:hover {
+tr.even.priority-high2, table.list tbody tr.even.priority-high2:hover {
   color: #900;
 }
 
-tr.even.priority-4 {
+tr.even.priority-high2 {
   background: #ffd4d4;
 }
 
-tr.priority-4 a {
+tr.priority-high2 a {
   color: #900;
 }
 
-tr.odd.priority-4 td, tr.even.priority-4 td {
+tr.odd.priority-high2 td, tr.even.priority-high2 td {
   border-color: #ffb4b4;
 }
 
-tr.odd.priority-3, table.list tbody tr.odd.priority-3:hover {
+tr.odd.priority-default, table.list tbody tr.odd.priority-default:hover {
   color: #900;
 }
 
-tr.odd.priority-3 {
+tr.odd.priority-default {
   background: #fee;
 }
 
-tr.even.priority-3, table.list tbody tr.even.priority-3:hover {
+tr.even.priority-default, table.list tbody tr.even.priority-default:hover {
   color: #900;
 }
 
-tr.even.priority-3 {
+tr.even.priority-default {
   background: #fff2f2;
 }
 
-tr.priority-3 a {
+tr.priority-default a {
   color: #900;
 }
 
-tr.odd.priority-3 td, tr.even.priority-3 td {
+tr.odd.priority-default td, tr.even.priority-default td {
   border-color: #fcc;
 }
 
-tr.odd.priority-1, table.list tbody tr.odd.priority-1:hover {
+tr.odd.priority-lowest, table.list tbody tr.odd.priority-lowest:hover {
   color: #559;
 }
 
-tr.odd.priority-1 {
+tr.odd.priority-lowest {
   background: #eaf7ff;
 }
 
-tr.even.priority-1, table.list tbody tr.even.priority-1:hover {
+tr.even.priority-lowest, table.list tbody tr.even.priority-lowest:hover {
   color: #559;
 }
 
-tr.even.priority-1 {
+tr.even.priority-lowest {
   background: #f2faff;
 }
 
-tr.priority-1 a {
+tr.priority-lowest a {
   color: #559;
 }
 
-tr.odd.priority-1 td, tr.even.priority-1 td {
+tr.odd.priority-lowest td, tr.even.priority-lowest td {
   border-color: #add7f3;
 }
 


### PR DESCRIPTION
Colouring issues based on the id of the IssuePriority record is risky: it's not granted that they have ids 1 to 5.
In fact, they are only required to be in the right order. 

Using priority-highest instead of priority-5 solves this problem.
