### PR TITLE
Allow both http and https sites to pull fonts without mixed content warnings

### DIFF
--- a/sass/application.scss
+++ b/sass/application.scss
@@ -2,7 +2,7 @@
 @import url(../../../stylesheets/application.css);
 
 // Open Sans
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800);
 
 $gray-dark: #202020;
 $gray-text: #484848;

--- a/stylesheets/application.css
+++ b/stylesheets/application.css
@@ -1,5 +1,5 @@
 @import url(../../../stylesheets/application.css);
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800);
 /* load the default Redmine stylesheet */
 .input_tiny {
   width: 50px;


### PR DESCRIPTION
This is called a "Protocol-relative URL", by the way